### PR TITLE
VP-1650: Fix thumbnail generation for different paths

### DIFF
--- a/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ImagesChangesProvider.cs
+++ b/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ImagesChangesProvider.cs
@@ -10,174 +10,186 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 {
-    public class BlobImagesChangesProvider : IImagesChangesProvider
-    {
-        public bool IsTotalCountSupported => true;
+	public class BlobImagesChangesProvider : IImagesChangesProvider
+	{
+		public bool IsTotalCountSupported => true;
 
-        private readonly IBlobStorageProvider _storageProvider;
-        private readonly IThumbnailOptionSearchService _thumbnailOptionSearchService;
+		private readonly IBlobStorageProvider _storageProvider;
+		private readonly IThumbnailOptionSearchService _thumbnailOptionSearchService;
 
-        private IList<ImageChange> _changeBlobs;
+		private readonly Dictionary<string, IList<ImageChange>> _blobChangesCache = new Dictionary<string, IList<ImageChange>>(StringComparer.InvariantCultureIgnoreCase);
 
-        private readonly string[] _imageExtensions = { ".bmp", ".gif", ".jpg", ".jpeg", ".jpe", ".jif", ".jfif", ".jfi", ".png", ".tiff", ".tif" };
+		private readonly string[] _imageExtensions = { ".bmp", ".gif", ".jpg", ".jpeg", ".jpe", ".jif", ".jfif", ".jfi", ".png", ".tiff", ".tif" };
 
-        public BlobImagesChangesProvider(IBlobStorageProvider storageProvider, IThumbnailOptionSearchService thumbnailOptionSearchService)
-        {
-            _storageProvider = storageProvider;
-            _thumbnailOptionSearchService = thumbnailOptionSearchService;
-        }
+		public BlobImagesChangesProvider(IBlobStorageProvider storageProvider, IThumbnailOptionSearchService thumbnailOptionSearchService)
+		{
+			_storageProvider = storageProvider;
+			_thumbnailOptionSearchService = thumbnailOptionSearchService;
+		}
 
-        protected virtual IList<ImageChange> GetChangeFiles(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
-        {
-            var options = GetOptionsCollection();
-            var allBlobInfos = ReadBlobFolder(task.WorkPath, token);
-            var orignalBlobInfos = GetOriginalItems(allBlobInfos, options.Select(x => x.FileSuffix).ToList());
+		protected virtual IList<ImageChange> ScanBlobForChanges(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
+		{
+			var options = GetOptionsCollection();
+			var allBlobInfos = ReadBlobFolder(task.WorkPath, token);
+			var orignalBlobInfos = GetOriginalItems(allBlobInfos, options.Select(x => x.FileSuffix).ToList());
 
-            var result = new List<ImageChange>();
-            foreach (var blobInfo in orignalBlobInfos)
-            {
-                token?.ThrowIfCancellationRequested();
+			var result = new List<ImageChange>();
+			foreach (var blobInfo in orignalBlobInfos)
+			{
+				token?.ThrowIfCancellationRequested();
 
-                var imageChange = new ImageChange
-                {
-                    Name = blobInfo.FileName,
-                    Url = blobInfo.Url,
-                    ModifiedDate = blobInfo.ModifiedDate,
-                    ChangeState = !changedSince.HasValue ? EntryState.Added : GetItemState(blobInfo, changedSince, task.ThumbnailOptions)
-                };
-                result.Add(imageChange);
-            }
-            return result.Where(x=>x.ChangeState != EntryState.Unchanged).ToList();
-        }
+				var imageChange = new ImageChange
+				{
+					Name = blobInfo.FileName,
+					Url = blobInfo.Url,
+					ModifiedDate = blobInfo.ModifiedDate,
+					ChangeState = !changedSince.HasValue ? EntryState.Added : GetItemState(blobInfo, changedSince, task.ThumbnailOptions)
+				};
+				result.Add(imageChange);
+			}
+			return result.Where(x => x.ChangeState != EntryState.Unchanged).ToList();
+		}
 
-        #region Implementation of IImagesChangesProvider
+		#region Implementation of IImagesChangesProvider
 
-        public long GetTotalChangesCount(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
-        {
-            if (_changeBlobs == null)
-            {
-                _changeBlobs = GetChangeFiles(task, changedSince, token);
-            }
-            return _changeBlobs.Count;
-        }
+		public long GetTotalChangesCount(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
+		{
+			var changedBlobs = GetChangedBlobs(task, changedSince, token);
 
-        public ImageChange[] GetNextChangesBatch(ThumbnailTask task, DateTime? changedSince, long? skip, long? take, ICancellationToken token)
-        {
-            if (_changeBlobs == null)
-            {
-                _changeBlobs = GetChangeFiles(task, changedSince, token);
-            }
+			return changedBlobs.Count;
+		}
 
-            var count = _changeBlobs.Count;
+		public ImageChange[] GetNextChangesBatch(ThumbnailTask task, DateTime? changedSince, long? skip, long? take, ICancellationToken token)
+		{
+			var changedBlobs = GetChangedBlobs(task, changedSince, token);
 
-            if (skip >= count)
-            {
-                return new ImageChange[] {};
-            }
+			var count = changedBlobs.Count;
 
-            return _changeBlobs.Skip((int)skip).Take((int)take).ToArray();
-        }
+			if (skip >= count)
+			{
+				return Array.Empty<ImageChange>();
+			}
 
-        #endregion
+			return changedBlobs.Skip((int)skip).Take((int)take).ToArray();
+		}
 
-        protected virtual ICollection<BlobInfo> ReadBlobFolder(string folderPath, ICancellationToken token)
-        {
-            token?.ThrowIfCancellationRequested();
-            
-            var result = new List<BlobInfo>();
+		#endregion
 
-            var searchResults = _storageProvider.Search(folderPath, null);
-            searchResults.Items = searchResults.Items.Where(item => _imageExtensions.Contains(Path.GetExtension(item.FileName))).ToList();
+		protected virtual ICollection<BlobInfo> ReadBlobFolder(string folderPath, ICancellationToken token)
+		{
+			token?.ThrowIfCancellationRequested();
 
-            result.AddRange(searchResults.Items);
-            foreach (var blobFolder in searchResults.Folders)
-            {
-                var folderResult = ReadBlobFolder(blobFolder.RelativeUrl, token);
-                result.AddRange(folderResult);
-            }
+			var result = new List<BlobInfo>();
 
-            return result;
-        }
+			var searchResults = _storageProvider.Search(folderPath, null);
+			searchResults.Items = searchResults.Items.Where(item => _imageExtensions.Contains(Path.GetExtension(item.FileName))).ToList();
 
-        /// <summary>
-        /// Check if image is exist in blob storage by url.
-        /// </summary>
-        /// <param name="imageUrl">Image url.</param>
-        /// <returns>
-        /// EntryState if image exist.
-        /// Null is image is empty
-        /// </returns>
-        protected virtual bool Exists(string imageUrl)
-        {
-            var blobInfo = _storageProvider.GetBlobInfo(imageUrl);
-            return blobInfo != null;
-        }
+			result.AddRange(searchResults.Items);
+			foreach (var blobFolder in searchResults.Folders)
+			{
+				var folderResult = ReadBlobFolder(blobFolder.RelativeUrl, token);
+				result.AddRange(folderResult);
+			}
 
-        protected virtual EntryState GetItemState(BlobInfo blobInfo, DateTime? changedSince, IList<ThumbnailOption> options)
-        {
-            if (!changedSince.HasValue)
-            {
-                return EntryState.Added;
-            }
+			return result;
+		}
 
-            foreach (var option in options)
-            {
-                if (!Exists(blobInfo.Url.GenerateThumbnailName(option.FileSuffix)))
-                {
-                    return EntryState.Added;
-                }
-            }
+		/// <summary>
+		/// Check if image is exist in blob storage by url.
+		/// </summary>
+		/// <param name="imageUrl">Image url.</param>
+		/// <returns>
+		/// EntryState if image exist.
+		/// Null is image is empty
+		/// </returns>
+		protected virtual bool Exists(string imageUrl)
+		{
+			var blobInfo = _storageProvider.GetBlobInfo(imageUrl);
+			return blobInfo != null;
+		}
 
-            if (blobInfo.ModifiedDate.HasValue && blobInfo.ModifiedDate >= changedSince)
-            {
-                return EntryState.Modified;
-            }
+		protected virtual EntryState GetItemState(BlobInfo blobInfo, DateTime? changedSince, IList<ThumbnailOption> options)
+		{
+			if (!changedSince.HasValue)
+			{
+				return EntryState.Added;
+			}
 
-            return EntryState.Unchanged;
-        }
+			foreach (var option in options)
+			{
+				if (!Exists(blobInfo.Url.GenerateThumbnailName(option.FileSuffix)))
+				{
+					return EntryState.Added;
+				}
+			}
 
-        //get all options to create a map of all potential file names
-        protected virtual ICollection<ThumbnailOption> GetOptionsCollection()
-        {
-            var options = _thumbnailOptionSearchService.Search(new ThumbnailOptionSearchCriteria()
-            {
-                Take = Int32.MaxValue
-            });
+			if (blobInfo.ModifiedDate.HasValue && blobInfo.ModifiedDate >= changedSince)
+			{
+				return EntryState.Modified;
+			}
 
-            return options.Results.ToList();
-        }
+			return EntryState.Unchanged;
+		}
 
-        /// <summary>
-        /// Calculate the original images
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="suffixCollection"></param>
-        /// <returns></returns>
-        protected virtual ICollection<BlobInfo> GetOriginalItems(ICollection<BlobInfo> source, ICollection<string> suffixCollection)
-        {
-            var result = new List<BlobInfo>();
+		//get all options to create a map of all potential file names
+		protected virtual ICollection<ThumbnailOption> GetOptionsCollection()
+		{
+			var options = _thumbnailOptionSearchService.Search(new ThumbnailOptionSearchCriteria()
+			{
+				Take = Int32.MaxValue
+			});
 
-            foreach (var blobInfo in source)
-            {
-                var name = blobInfo.FileName;
+			return options.Results.ToList();
+		}
 
-                var present = false;
-                foreach (var suffix in suffixCollection)
-                {
-                    if (name.Contains("_" + suffix))
-                    {
-                        present = true;
-                        break;
-                    }
-                }
+		/// <summary>
+		/// Calculate the original images
+		/// </summary>
+		/// <param name="source"></param>
+		/// <param name="suffixCollection"></param>
+		/// <returns></returns>
+		protected virtual ICollection<BlobInfo> GetOriginalItems(ICollection<BlobInfo> source, ICollection<string> suffixCollection)
+		{
+			var result = new List<BlobInfo>();
 
-                if (!present)
-                {
-                    result.Add(blobInfo);
-                }
-            }
+			foreach (var blobInfo in source)
+			{
+				var name = blobInfo.FileName;
 
-            return result;
-        }
-    }
+				var present = false;
+				foreach (var suffix in suffixCollection)
+				{
+					if (name.Contains("_" + suffix))
+					{
+						present = true;
+						break;
+					}
+				}
+
+				if (!present)
+				{
+					result.Add(blobInfo);
+				}
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// Gets changed blobs. Caches changes based on location path.
+		/// </summary>
+		/// <param name="task"></param>
+		/// <param name="changedSince"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		protected virtual IList<ImageChange> GetChangedBlobs(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
+		{
+			if (!_blobChangesCache.ContainsKey(task.WorkPath))
+			{
+				_blobChangesCache.Add(task.WorkPath, ScanBlobForChanges(task, changedSince, token));
+			}
+
+			return _blobChangesCache[task.WorkPath];
+		}
+	}
 }


### PR DESCRIPTION
Before only one task blob changes were cached and used as change source for all other task, even with different path. Now cache is made based on generation task WorkPath.