### PR TITLE
VP-1993 Suppress Error when user trying to generate thumbnails after deleting assets

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/DefaultThumbnailGenerator.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/DefaultThumbnailGenerator.cs
@@ -27,11 +27,11 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
         /// Generates thumbnails asynchronously
         /// </summary>
         /// <param name="source">Path to source picture</param>
-        /// <param name="destPath">Target for generated thumbnail</param>
+        /// <param name="destination">Target for generated thumbnail</param>
         /// <param name="options">Represents generation options</param>
         /// <param name="token">Allows cancel operation</param>
         /// <returns></returns>
-        public virtual async Task<ThumbnailGenerationResult> GenerateThumbnailsAsync(string source, string destPath, IList<ThumbnailOption> options, ICancellationToken token)
+        public virtual async Task<ThumbnailGenerationResult> GenerateThumbnailsAsync(string source, string destination, IList<ThumbnailOption> options, ICancellationToken token)
         {
             token?.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/DefaultThumbnailGenerator.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/DefaultThumbnailGenerator.cs
@@ -38,10 +38,7 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
             var originalImage = await _imageService.LoadImageAsync(source, out var format);
             if (originalImage == null)
             {
-                return new ThumbnailGenerationResult
-                {
-                    Errors = { $"Cannot generate thumbnail: {source} does not have a valid image format" }
-                };
+                return null;
             }
 
             var result = new ThumbnailGenerationResult();

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
@@ -58,7 +58,7 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
                         var result = await _generator.GenerateThumbnailsAsync(fileChange.Url, task.WorkPath, task.ThumbnailOptions, token);
                         progressInfo.ProcessedCount++;
 
-                        if (!result.Errors.IsNullOrEmpty())
+                        if (result != null && !result.Errors.IsNullOrEmpty())
                         {
                             progressInfo.Errors.AddRange(result.Errors);
                         }


### PR DESCRIPTION
Don't throw the error when an image can't be loaded from storage.