### PR TITLE
VP-2527: Execute and save task results one by one

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
@@ -27,7 +27,7 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 
         public async Task ProcessTasksAsync(ICollection<ThumbnailTask> tasks, bool regenerate, Action<ThumbnailTaskProgress> progressCallback, ICancellationToken token)
         {
-            var progressInfo = new ThumbnailTaskProgress { Message = "Reading the tasks..." };
+            var progressInfo = new ThumbnailTaskProgress { Message = "Getting changes count…" };
 
             if (_imageChangesProvider.IsTotalCountSupported)
             {
@@ -70,9 +70,6 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
                     token?.ThrowIfCancellationRequested();
                 }
             }
-
-            progressInfo.Message = "Finished generating thumbnails!";
-            progressCallback(progressInfo);
         }
     }
 }


### PR DESCRIPTION
It is done to allow completed tasks log their results and not to wait for other long running tasks (e.g. when call ProcessAll). Thus even if all tasks job is still in process, or failed, the already generated images will not be generated second time (e.g. if run specific tasks manually or restart ProcessAll tasks) - thanks to updated LastTun date.