### PR TITLE
VP-2527: Change cache expiration for blob changes

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Data/Caching/BlobChangesCacheRegion.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Caching/BlobChangesCacheRegion.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Microsoft.Extensions.Primitives;
+using VirtoCommerce.ImageToolsModule.Core.Models;
+using VirtoCommerce.Platform.Core.Caching;
+
+namespace VirtoCommerce.ImageToolsModule.Data.Caching
+{
+    public class BlobChangesCacheRegion : CancellableCacheRegion<BlobChangesCacheRegion>
+    {
+        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _regionTokenLookup = new ConcurrentDictionary<string, CancellationTokenSource>();
+
+        public static IChangeToken CreateChangeToken(ThumbnailTask task, DateTime? changedSince)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            var regionTokenKey = GetRegionTokenKey(task, changedSince);
+            var cancellationTokenSource = _regionTokenLookup.GetOrAdd(regionTokenKey, new CancellationTokenSource());
+
+            return new CompositeChangeToken(new[] { CreateChangeToken(), new CancellationChangeToken(cancellationTokenSource.Token) });
+        }
+
+        public static void ExpireTaskRun(ThumbnailTask task, DateTime? changesSince)
+        {
+            var regionTokenKey = GetRegionTokenKey(task, changesSince);
+
+            if (_regionTokenLookup.TryRemove(regionTokenKey, out var token))
+            {
+                token.Cancel();
+            }
+        }
+
+        private static string GetRegionTokenKey(ThumbnailTask task, DateTime? changedSince)
+        {
+            return CacheKey.With(task.WorkPath, changedSince?.ToString());
+        }
+    }
+}

--- a/src/VirtoCommerce.ImageToolsModule.Data/Caching/BlobChangesCacheRegion.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Caching/BlobChangesCacheRegion.cs
@@ -26,6 +26,11 @@ namespace VirtoCommerce.ImageToolsModule.Data.Caching
 
         public static void ExpireTaskRun(ThumbnailTask task, DateTime? changesSince)
         {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
             var regionTokenKey = GetRegionTokenKey(task, changesSince);
 
             if (_regionTokenLookup.TryRemove(regionTokenKey, out var token))

--- a/src/VirtoCommerce.ImageToolsModule.Data/Caching/ThumbnailCacheRegion.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Caching/ThumbnailCacheRegion.cs
@@ -1,8 +1,0 @@
-using VirtoCommerce.Platform.Core.Caching;
-
-namespace VirtoCommerce.ImageToolsModule.Data.Caching
-{
-    public class ThumbnailCacheRegion : CancellableCacheRegion<ThumbnailCacheRegion>
-    {
-    }
-}

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
@@ -79,10 +79,10 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 
             if (skip >= count)
             {
-                return new ImageChange[] { };
+                return Array.Empty<ImageChange>();
             }
 
-            return changedFiles.Skip((int)skip).Take((int)take).ToArray();
+            return changedFiles.Skip((int)(skip ?? 0)).Take((int)(take ?? 0)).ToArray();
         }
 
         #endregion

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
@@ -33,11 +33,10 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
         protected virtual async Task<IList<ImageChange>> GetChangeFiles(ThumbnailTask task, DateTime? changedSince, ICancellationToken token)
         {
             var options = await GetOptionsCollection();
-            var cacheKey = CacheKey.With(GetType(), "GetChangeFiles", task.WorkPath, string.Join(":", options.Select(x => x.FileSuffix)));
+            var cacheKey = CacheKey.With(GetType(), "GetChangeFiles", task.WorkPath, changedSince?.ToString(), string.Join(":", options.Select(x => x.FileSuffix)));
             return await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
             {
-                cacheEntry.AddExpirationToken(ThumbnailCacheRegion.CreateChangeToken());
-                cacheEntry.SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+                cacheEntry.AddExpirationToken(BlobChangesCacheRegion.CreateChangeToken(task, changedSince));
 
                 var allBlobInfos = await ReadBlobFolderAsync(task.WorkPath, token);
                 var orignalBlobInfos = GetOriginalItems(allBlobInfos, options.Select(x => x.FileSuffix).ToList());

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
         {
             try
             {
-                var progressInfo = new ThumbnailTaskProgress { Message = "Reading the tasks..." };
+                var progressInfo = new ThumbnailTaskProgress { Message = "Getting changes count…" };
 
                 if (_imageChangesProvider.IsTotalCountSupported)
                 {
@@ -81,10 +81,6 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 
                     ClearCache(task, regenerate);
                 }
-
-                progressInfo.Message = "Finished generating thumbnails!";
-                progressCallback(progressInfo);
-
             }
             finally
             {

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ThumbnailGenerationProcessor.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using VirtoCommerce.ImageToolsModule.Core;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
+using VirtoCommerce.ImageToolsModule.Data.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
 
@@ -15,6 +16,8 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
         private readonly IThumbnailGenerator _generator;
         private readonly ISettingsManager _settingsManager;
         private readonly IImagesChangesProvider _imageChangesProvider;
+
+        private readonly HashSet<string> tasksToExpireChangesCache = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         public ThumbnailGenerationProcessor(IThumbnailGenerator generator,
             ISettingsManager settingsManager,
@@ -27,52 +30,88 @@ namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 
         public async Task ProcessTasksAsync(ICollection<ThumbnailTask> tasks, bool regenerate, Action<ThumbnailTaskProgress> progressCallback, ICancellationToken token)
         {
-            var progressInfo = new ThumbnailTaskProgress { Message = "Reading the tasks..." };
-
-            if (_imageChangesProvider.IsTotalCountSupported)
+            try
             {
-                foreach (var task in tasks)
+                var progressInfo = new ThumbnailTaskProgress { Message = "Reading the tasks..." };
+
+                if (_imageChangesProvider.IsTotalCountSupported)
                 {
-                    var changedSince = regenerate ? null : task.LastRun;
-                    progressInfo.TotalCount += await _imageChangesProvider.GetTotalChangesCount(task, changedSince, token);
+                    foreach (var task in tasks)
+                    {
+                        tasksToExpireChangesCache.Add(task.Id);
+
+                        var changesSince = GetChangesSinceDate(task, regenerate);
+                        progressInfo.TotalCount += await _imageChangesProvider.GetTotalChangesCount(task, changesSince, token);
+                    }
                 }
-            }
 
-            progressCallback(progressInfo);
-
-            var pageSize = _settingsManager.GetValue(ModuleConstants.Settings.General.ProcessBatchSize.Name, 50);
-            foreach (var task in tasks)
-            {
-                progressInfo.Message = $"Procesing task {task.Name}...";
                 progressCallback(progressInfo);
 
-                var skip = 0;
-                while (true)
+                var pageSize = _settingsManager.GetValue(ModuleConstants.Settings.General.ProcessBatchSize.Name, 50);
+                foreach (var task in tasks)
                 {
-                    var changes = await _imageChangesProvider.GetNextChangesBatch(task, regenerate ? null : task.LastRun, skip, pageSize, token);
-                    if (!changes.Any())
-                        break;
+                    progressInfo.Message = $"Procesing task {task.Name}...";
+                    progressCallback(progressInfo);
 
-                    foreach (var fileChange in changes)
+                    tasksToExpireChangesCache.Add(task.Id);
+
+                    var skip = 0;
+                    while (true)
                     {
-                        var result = await _generator.GenerateThumbnailsAsync(fileChange.Url, task.WorkPath, task.ThumbnailOptions, token);
-                        progressInfo.ProcessedCount++;
+                        var changes = await _imageChangesProvider.GetNextChangesBatch(task, GetChangesSinceDate(task, regenerate), skip, pageSize, token);
+                        if (!changes.Any())
+                            break;
 
-                        if (result != null && !result.Errors.IsNullOrEmpty())
+                        foreach (var fileChange in changes)
                         {
-                            progressInfo.Errors.AddRange(result.Errors);
+                            var result = await _generator.GenerateThumbnailsAsync(fileChange.Url, task.WorkPath, task.ThumbnailOptions, token);
+                            progressInfo.ProcessedCount++;
+
+                            if (result != null && !result.Errors.IsNullOrEmpty())
+                            {
+                                progressInfo.Errors.AddRange(result.Errors);
+                            }
                         }
+
+                        skip += changes.Length;
+
+                        progressCallback(progressInfo);
+                        token?.ThrowIfCancellationRequested();
                     }
 
-                    skip += changes.Length;
-
-                    progressCallback(progressInfo);
-                    token?.ThrowIfCancellationRequested();
+                    ClearCache(task, regenerate);
                 }
-            }
 
-            progressInfo.Message = "Finished generating thumbnails!";
-            progressCallback(progressInfo);
+                progressInfo.Message = "Finished generating thumbnails!";
+                progressCallback(progressInfo);
+
+            }
+            finally
+            {
+                ClearCache(tasks, regenerate);
+            }
+        }
+
+        private void ClearCache(ICollection<ThumbnailTask> tasks, bool regenerate)
+        {
+            foreach (var task in tasks)
+            {
+                ClearCache(task, regenerate);
+            }
+        }
+
+        private void ClearCache(ThumbnailTask task, bool regenerate)
+        {
+            if (tasksToExpireChangesCache.Contains(task.Id))
+            {
+                tasksToExpireChangesCache.Remove(task.Id);
+                BlobChangesCacheRegion.ExpireTaskRun(task, GetChangesSinceDate(task, regenerate));
+            }
+        }
+
+        private static DateTime? GetChangesSinceDate(ThumbnailTask task, bool regenerate)
+        {
+            return regenerate ? null : task.LastRun;
         }
     }
 }

--- a/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
@@ -63,12 +63,14 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
                 var tasks = await _taskService.GetByIdsAsync(generateRequest.TaskIds);
 
                 var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
+                var runTime = DateTime.UtcNow;
+
                 await _thumbnailProcessor.ProcessTasksAsync(tasks, generateRequest.Regenerate, progressCallback, cancellationTokenWrapper);
 
                 //update tasks in case of successful generation
                 foreach (var task in tasks)
                 {
-                    task.LastRun = DateTime.UtcNow;
+                    task.LastRun = runTime;
                 }
 
                 await _taskService.SaveChangesAsync(tasks);
@@ -112,12 +114,14 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
 
             Action<ThumbnailTaskProgress> progressCallback = x => { };
             var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
+            var runTime = DateTime.UtcNow;
+
             await _thumbnailProcessor.ProcessTasksAsync(tasks.Results, false, progressCallback, cancellationTokenWrapper);
 
             //update tasks in case of successful generation
             foreach (var task in tasks.Results)
             {
-                task.LastRun = DateTime.UtcNow;
+                task.LastRun = runTime;
             }
 
             await _taskService.SaveChangesAsync(tasks.Results);

--- a/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
@@ -62,18 +63,7 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
                 //wrap token 
                 var tasks = await _taskService.GetByIdsAsync(generateRequest.TaskIds);
 
-                var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
-                var runTime = DateTime.UtcNow;
-
-                await _thumbnailProcessor.ProcessTasksAsync(tasks, generateRequest.Regenerate, progressCallback, cancellationTokenWrapper);
-
-                //update tasks in case of successful generation
-                foreach (var task in tasks)
-                {
-                    task.LastRun = runTime;
-                }
-
-                await _taskService.SaveChangesAsync(tasks);
+                await PerformGeneration(tasks, generateRequest.Regenerate, progressCallback, cancellationToken);
             }
             catch (JobAbortedException)
             {
@@ -113,18 +103,30 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
             var tasks = await _taskSearchService.SearchAsync(new ThumbnailTaskSearchCriteria() { Take = thumbnailTasks.TotalCount, Skip = 0 });
 
             Action<ThumbnailTaskProgress> progressCallback = x => { };
+
+            await PerformGeneration(tasks.Results, false, progressCallback, cancellationToken);
+        }
+
+        private async Task PerformGeneration(IEnumerable<ThumbnailTask> tasks, bool regenerate, Action<ThumbnailTaskProgress> progressCallback, IJobCancellationToken cancellationToken)
+        {
             var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
-            var runTime = DateTime.UtcNow;
 
-            await _thumbnailProcessor.ProcessTasksAsync(tasks.Results, false, progressCallback, cancellationTokenWrapper);
-
-            //update tasks in case of successful generation
-            foreach (var task in tasks.Results)
+            foreach (var task in tasks)
             {
+                // Better to run and save tasks one by one to save LastRun date once every task is completed, opposing to waiting all tasks completion, as it could be a long process.
+                var oneTaskArray = new[] { task };
+                //Need to save runTime at start in order to not loose changes that may be done between the moment of getting changes and the task completion.
+                var runTime = DateTime.UtcNow;
+
+                await _thumbnailProcessor.ProcessTasksAsync(oneTaskArray, regenerate, progressCallback, cancellationTokenWrapper);
+
                 task.LastRun = runTime;
+
+                await _taskService.SaveChangesAsync(oneTaskArray);
             }
 
-            await _taskService.SaveChangesAsync(tasks.Results);
+            var progressInfo = new ThumbnailTaskProgress { Message = "Finished generating thumbnails!" };
+            progressCallback(progressInfo);
         }
     }
 }

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
@@ -58,12 +58,12 @@ namespace VirtoCommerce.ImageToolsModule.Tests
                     }
                 });
 
-            var result = new BlobImagesChangesProvider(StorageProviderMock.Object, ThumbnailOptionSearchServiceMock.Object, GetPlatformMemotyCache());
+            var result = new BlobImagesChangesProvider(StorageProviderMock.Object, ThumbnailOptionSearchServiceMock.Object, GetPlatformMemoryCache());
 
             return result;
         }
 
-        private IPlatformMemoryCache GetPlatformMemotyCache()
+        private IPlatformMemoryCache GetPlatformMemoryCache()
         {
             var memoryCache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
             return new PlatformMemoryCache(memoryCache, Options.Create(new CachingOptions()), new Mock<ILogger<PlatformMemoryCache>>().Object);

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.ImageToolsModule.Core.Models;
+using VirtoCommerce.ImageToolsModule.Core.Services;
+using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
+using VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.Platform.Core.Caching;
+
+namespace VirtoCommerce.ImageToolsModule.Tests
+{
+    public abstract class BlobChangesProviderTestBase
+    {
+        public readonly string OptionSuffix = "64x64";
+
+        public Mock<IBlobStorageProvider> StorageProviderMock { get; private set; }
+        public Mock<IThumbnailOptionSearchService> ThumbnailOptionSearchServiceMock { get; private set; }
+
+        protected BlobChangesProviderTestBase()
+        {
+            StorageProviderMock = new Mock<IBlobStorageProvider>();
+            ThumbnailOptionSearchServiceMock = new Mock<IThumbnailOptionSearchService>();
+        }
+
+        public IImagesChangesProvider GetBlobImagesChangesProvider(IEnumerable<BlobEntry> blobContents)
+        {
+            StorageProviderMock.Setup(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<string, string>((folderUrl, keyword) =>
+                {
+
+                    var searchResult = blobContents.Where(x => x.Url.StartsWith(folderUrl)).ToList();
+
+                    return Task.FromResult(new BlobEntrySearchResult()
+                    {
+                        TotalCount = searchResult.Count,
+                        Results = searchResult,
+                    });
+                });
+
+            StorageProviderMock.Setup(x => x.GetBlobInfoAsync(It.IsAny<string>()))
+                .Returns<string>(
+                    x => Task.FromResult(x.EndsWith(OptionSuffix) ? null : new BlobInfo() { })
+                );
+
+            ThumbnailOptionSearchServiceMock.Setup(x => x.SearchAsync(It.IsAny<ThumbnailOptionSearchCriteria>()))
+                .ReturnsAsync(new ThumbnailOptionSearchResult()
+                {
+                    TotalCount = 1,
+                    Results = new List<ThumbnailOption>()
+                    {
+                        new ThumbnailOption() { FileSuffix = OptionSuffix },
+                    }
+                });
+
+            var result = new BlobImagesChangesProvider(StorageProviderMock.Object, ThumbnailOptionSearchServiceMock.Object, GetPlatformMemotyCache());
+
+            return result;
+        }
+
+        private IPlatformMemoryCache GetPlatformMemotyCache()
+        {
+            var memoryCache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
+            return new PlatformMemoryCache(memoryCache, Options.Create(new CachingOptions()), new Mock<ILogger<PlatformMemoryCache>>().Object);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/BlobImagesChangesProviderTests.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/BlobImagesChangesProviderTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.ImageToolsModule.Core.Models;
+using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.ImageToolsModule.Tests
+{
+    public class BlobImagesChangesProviderTests : BlobChangesProviderTestBase
+    {
+        [Fact]
+        public async Task GetNextChangesBatch_TasksWithOneWorkPathAndOptions_CacheIsWorking()
+        {
+            // Arrange
+            var blobContents = new List<BlobEntry>()
+            {
+                new BlobInfo()
+                {
+                    Name = "Blob1.png",
+                    Url = "testPath/Blob1.png",
+                },
+            };
+            var changesProvider = GetBlobImagesChangesProvider(blobContents);
+            var thumbnailOption = new ThumbnailOption() { FileSuffix = OptionSuffix };
+            var workPath = "testPath";
+            var task1 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = workPath,
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var task2 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = workPath,
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var cancellationToken = new CancellationTokenWrapper(new CancellationToken());
+
+            // Act
+            var changes1 = await changesProvider.GetNextChangesBatch(task1, null, 0, 10, cancellationToken);
+            var changes2 = await changesProvider.GetNextChangesBatch(task2, null, 0, 10, cancellationToken);
+
+            //Assert
+            StorageProviderMock.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+            Assert.Single(changes1);
+            Assert.Single(changes2);
+            for (var i = 0; i < changes1.Length; i++)
+            {
+                Assert.Same(changes1[i], changes2[i]);
+            }
+        }
+
+        [Fact]
+        public async Task GetNextChangesBatch_TasksWithDifferentWorkPathAndOptions_UseDifferentValues()
+        {
+            // Arrange
+            var blobContents = new List<BlobEntry>()
+            {
+                new BlobInfo()
+                {
+                    Name = "Blob1.png",
+                    Url = "testPath1/Blob1.png",
+                },
+                new BlobInfo()
+                {
+                    Name = "Blob2.png",
+                    Url = "testPath2/Blob2.png",
+                },
+            };
+            var changesProvider = GetBlobImagesChangesProvider(blobContents);
+            var thumbnailOption = new ThumbnailOption() { FileSuffix = OptionSuffix };
+            var task1 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = "testPath1",
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var task2 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = "testPath2",
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var cancellationToken = new CancellationTokenWrapper(new CancellationToken());
+
+            // Act
+            var changes1 = await changesProvider.GetNextChangesBatch(task1, null, 0, 10, cancellationToken);
+            var changes2 = await changesProvider.GetNextChangesBatch(task2, null, 0, 10, cancellationToken);
+
+            //Assert
+            StorageProviderMock.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
+
+            Assert.Collection(changes1, x => Assert.Equal("Blob1.png", x.Name));
+            Assert.Collection(changes2, x => Assert.Equal("Blob2.png", x.Name));
+        }
+
+        [Fact]
+        public async Task GetNextChangesBatch_TasksWithOneWorkPathAndOptions_CacheIsWorkingWithGetTotalChangesCount()
+        {
+            // Arrange
+            var blobContents = new List<BlobEntry>()
+            {
+                new BlobInfo()
+                {
+                    Name = "Blob1.png",
+                    Url = "testPath/Blob1.png",
+                },
+            };
+            var changesProvider = GetBlobImagesChangesProvider(blobContents);
+            var thumbnailOption = new ThumbnailOption() { FileSuffix = OptionSuffix };
+            var workPath = "testPath";
+            var task = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = workPath,
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var cancellationToken = new CancellationTokenWrapper(new CancellationToken());
+
+            // Act
+            var changes = await changesProvider.GetNextChangesBatch(task, null, 0, 10, cancellationToken);
+            var count = await changesProvider.GetTotalChangesCount(task, null, cancellationToken);
+
+            //Assert
+            StorageProviderMock.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+            Assert.Collection(changes, x => Assert.Equal("Blob1.png", x.Name));
+            Assert.Equal(1, count);
+        }
+    }
+}

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/ThumbnailGenerationProcessorTests.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/ThumbnailGenerationProcessorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.ImageToolsModule.Core;
+using VirtoCommerce.ImageToolsModule.Core.Models;
+using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
+using VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration;
+using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.ImageToolsModule.Tests
+{
+    public class ThumbnailGenerationProcessorTests : BlobChangesProviderTestBase
+    {
+        private readonly Mock<IThumbnailGenerator> _generator;
+        private readonly Mock<ISettingsManager> _settingsManager;
+
+        public ThumbnailGenerationProcessorTests()
+        {
+            _generator = new Mock<IThumbnailGenerator>();
+
+            _settingsManager = new Mock<ISettingsManager>();
+            _settingsManager.Setup(x => x.GetObjectSettingAsync(It.Is<string>(x => x.Equals(ModuleConstants.Settings.General.ProcessBatchSize.Name)), null, null))
+                .Returns(Task.FromResult(new ObjectSettingEntry()));
+        }
+
+        [Fact]
+        public async Task ProcessTasksAsync_BlobChangesProviderCache_WorkingDuringOneRun()
+        {
+            // Arrange
+            var blobContents = new List<BlobEntry>()
+            {
+                new BlobInfo()
+                {
+                    Name = "Blob1.png",
+                    Url = "testPath/Blob1.png",
+                },
+            };
+            var imageChangesProvider = GetBlobImagesChangesProvider(blobContents);
+            var thumbnailGenerationProcessor = new ThumbnailGenerationProcessor(_generator.Object, _settingsManager.Object, imageChangesProvider);
+
+            var thumbnailOption = new ThumbnailOption() { FileSuffix = OptionSuffix };
+            var workPath = "testPath";
+            var task1 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = workPath,
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var cancellationToken = new CancellationTokenWrapper(new CancellationToken());
+
+            // Act
+
+            await thumbnailGenerationProcessor.ProcessTasksAsync(new[] { task1 }, false, x => { }, cancellationToken);
+
+            //Assert
+            StorageProviderMock.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+
+        }
+
+        [Fact]
+        public async Task ProcessTasksAsync_BlobChangesProviderCache_ExpiredAfterExecution()
+        {
+            // Arrange
+            var blobContents = new List<BlobEntry>()
+            {
+                new BlobInfo()
+                {
+                    Name = "Blob1.png",
+                    Url = "testPath/Blob1.png",
+                },
+            };
+            var imageChangesProvider = GetBlobImagesChangesProvider(blobContents);
+            var thumbnailGenerationProcessor = new ThumbnailGenerationProcessor(_generator.Object, _settingsManager.Object, imageChangesProvider);
+
+            var thumbnailOption = new ThumbnailOption() { FileSuffix = OptionSuffix };
+            var workPath = "testPath";
+            var task1 = new ThumbnailTask()
+            {
+                Id = Guid.NewGuid().ToString(),
+                LastRun = null,
+                WorkPath = workPath,
+                ThumbnailOptions = new List<ThumbnailOption>() { thumbnailOption },
+            };
+            var cancellationToken = new CancellationTokenWrapper(new CancellationToken());
+
+            // Act
+
+            await thumbnailGenerationProcessor.ProcessTasksAsync(new[] { task1 }, false, x => { }, cancellationToken);
+            await thumbnailGenerationProcessor.ProcessTasksAsync(new[] { task1 }, false, x => { }, cancellationToken);
+
+            //Assert
+            StorageProviderMock.Verify(x => x.SearchAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
+        }
+    }
+}


### PR DESCRIPTION
- Added changesSince date to the cache key;
- Removed SetAbsoluteExpiration(TimeSpan.FromMinutes(5)) as it could clear cache many times even while one big task execution in progress;
- Added BlobChanges caching based on path and changesSince date, expiration is done on task processing completion;
- Set 'LastRun' time to the time before processing;
- Made generation execute a task and save results one by one instead of a whole array at once;
- Added tests on caching and expiration;