### PR TITLE
VP-2527: Set 'LastRun' time to the time before processing

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
@@ -63,12 +63,14 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
                 var tasks = await _taskService.GetByIdsAsync(generateRequest.TaskIds);
 
                 var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
+                var runTime = DateTime.UtcNow;
+
                 await _thumbnailProcessor.ProcessTasksAsync(tasks, generateRequest.Regenerate, progressCallback, cancellationTokenWrapper);
 
                 //update tasks in case of successful generation
                 foreach (var task in tasks)
                 {
-                    task.LastRun = DateTime.UtcNow;
+                    task.LastRun = runTime;
                 }
 
                 await _taskService.SaveChangesAsync(tasks);
@@ -112,12 +114,14 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
 
             Action<ThumbnailTaskProgress> progressCallback = x => { };
             var cancellationTokenWrapper = new JobCancellationTokenWrapper(cancellationToken);
+            var runTime = DateTime.UtcNow;
+
             await _thumbnailProcessor.ProcessTasksAsync(tasks.Results, false, progressCallback, cancellationTokenWrapper);
 
             //update tasks in case of successful generation
             foreach (var task in tasks.Results)
             {
-                task.LastRun = DateTime.UtcNow;
+                task.LastRun = runTime;
             }
 
             await _taskService.SaveChangesAsync(tasks.Results);


### PR DESCRIPTION
This should be done to prevent "changes loss", if they were done in the interval between getting changes from the blob and all tasks completion save, when the date was updated before.