### PR TITLE
PT-4135: Use assets from newly created module instead of the platform

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
@@ -14,6 +14,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.57.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/BlobImagesChangesProvider.cs
@@ -8,7 +8,7 @@ using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.Services;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
 using VirtoCommerce.ImageToolsModule.Data.Caching;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 

--- a/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ImageService.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/ThumbnailGeneration/ImageService.cs
@@ -7,7 +7,7 @@ using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 
 namespace VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration
 {

--- a/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
         <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Core\VirtoCommerce.ImageToolsModule.Core.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
@@ -13,19 +13,20 @@
         <NoWarn>1701;1702;1705</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
-        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.57.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Core\VirtoCommerce.ImageToolsModule.Core.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.81.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Web/VirtoCommerce.ImageToolsModule.Web.csproj
@@ -18,7 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.57.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.81.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
+++ b/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
@@ -23,7 +23,7 @@
   <assemblyFile>VirtoCommerce.ImageToolsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.ImageToolsModule.Web.Module, VirtoCommerce.ImageToolsModule.Web</moduleType>
     <dependencies>
-      <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+      <dependency id="VirtoCommerce.Assets" version="1.0.0" />
     </dependencies>
   <groups>
     <group>commerce</group>

--- a/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
+++ b/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.ImageTools</id>
   <version>3.14.0</version>
   <version-tag />
-  <platformVersion>3.57.0</platformVersion>
+  <platformVersion>3.81.0</platformVersion>
   <title>Image tools module</title>
   <description>Image tools helps to automate image transformation procedures such as resizing and cropping</description>
   <authors>
@@ -22,6 +22,9 @@
   <tags>images</tags>
   <assemblyFile>VirtoCommerce.ImageToolsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.ImageToolsModule.Web.Module, VirtoCommerce.ImageToolsModule.Web</moduleType>
+    <dependencies>
+      <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+    </dependencies>
   <groups>
     <group>commerce</group>
   </groups>

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/BlobChangesProviderTestBase.cs
@@ -10,7 +10,7 @@ using VirtoCommerce.ImageToolsModule.Core.Services;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
 using VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration;
 using VirtoCommerce.Platform.Caching;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Caching;
 
 namespace VirtoCommerce.ImageToolsModule.Tests

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/BlobImagesChangesProviderTests.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/BlobImagesChangesProviderTests.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using VirtoCommerce.ImageToolsModule.Core.Models;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using Xunit;
 

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/ThumbnailGenerationProcessorTests.cs
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/ThumbnailGenerationProcessorTests.cs
@@ -7,7 +7,7 @@ using VirtoCommerce.ImageToolsModule.Core;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
 using VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
 using Xunit;

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/VirtoCommerce.ImageToolsModule.Tests.csproj
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/VirtoCommerce.ImageToolsModule.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/tests/VirtoCommerce.ImageToolsModule.Tests/VirtoCommerce.ImageToolsModule.Tests.csproj
+++ b/tests/VirtoCommerce.ImageToolsModule.Tests/VirtoCommerce.ImageToolsModule.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />


### PR DESCRIPTION
## Description
Use assets from newly created module instead of the platform
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4135
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ImageTools_3.14.0-pr-80.zip
