### PR TITLE
PT-11660: Multiple thumbnail processing jobs can be started at same time.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-VirtoCommerce.ImageTools module represents a functionality that helps working with images. This module allows generating thumbnails, which can be used for upload instead of the original images.
+Virto Commerce Image Tools module represents a functionality that helps working with images. This module allows generating thumbnails, which can be used on web sites instead of the original images.
 
 ## Key features
 

--- a/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/BackgroundJobs/ThumbnailProcessJob.cs
@@ -121,7 +121,6 @@ namespace VirtoCommerce.ImageToolsModule.Web.BackgroundJobs
 
                     var progressInfo = new ThumbnailTaskProgress { Message = "Thumbnails generated successfully!" };
                     progressCallback(progressInfo);
-
                 }
             }
             catch (DistributedLockTimeoutException)

--- a/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
+++ b/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.ImageTools</id>
   <version>3.208.0</version>
   <version-tag />
   <platformVersion>3.200.0</platformVersion>
-  <title>Image tools module</title>
-  <description>Image tools helps to automate image transformation procedures such as resizing and cropping</description>
+  <title>Image Tools</title>
+  <description>Image tools helps to automate thumbnail generation procedures with resizing and cropping</description>
   <authors>
     <author>Konstantin Savosteev</author>
     <author>Nikolay Prohorov</author>


### PR DESCRIPTION
## Description
fix: Multiple processing jobs can be started at same time. After the fix, only one thumbnail job can be executed at one time (manually or by schedule), other call will throw exception.

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/PT-11660
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ImageTools_3.208.0-pr-101-6e07.zip
