### PR TITLE
VCST-2867: Update SixLabors.ImageSharp to version 3.1.7

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
feat: Upgraded SixLabors.ImageSharp package from version 3.1.5 to 3.1.7 in the VirtoCommerce.ImageToolsModule.Core.csproj file. This update may include bug fixes, performance improvements, or new features.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2868
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ImageTools_3.809.0-pr-116-3dac.zip