### PR TITLE
VCST-5686: Use BackgroundJobs

### DIFF
--- a/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Core/VirtoCommerce.ImageToolsModule.Core.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ImageToolsModule.Data.MySql/VirtoCommerce.ImageToolsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data.MySql/VirtoCommerce.ImageToolsModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Data.PostgreSql/VirtoCommerce.ImageToolsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data.PostgreSql/VirtoCommerce.ImageToolsModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Data.SqlServer/VirtoCommerce.ImageToolsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data.SqlServer/VirtoCommerce.ImageToolsModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Data\VirtoCommerce.ImageToolsModule.Data.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Data/BackgroundJobs/ThumbnailProcessJob.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/BackgroundJobs/ThumbnailProcessJob.cs
@@ -1,54 +1,75 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using Hangfire;
-using Hangfire.Server;
-using Hangfire.Storage;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.PushNotifications;
 using VirtoCommerce.ImageToolsModule.Core.Services;
 using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
+using VirtoCommerce.Platform.Core.DistributedLock;
+using VirtoCommerce.Platform.Core.Exceptions;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.PushNotifications;
-using VirtoCommerce.Platform.Hangfire;
 
 namespace VirtoCommerce.ImageToolsModule.Data.BackgroundJobs
 {
     public class ThumbnailProcessJob
     {
+        /// <summary>
+        /// Resource key of the distributed lock that keeps two generation runs from overlapping. Same name the
+        /// Hangfire implementation used, so a mixed-version cluster mid-upgrade still contends on one key.
+        /// </summary>
+        public const string GenerationLockKey = "ThumbnailProcessJob";
+
+        /// <summary>
+        /// How long the generation lock is held. Unlike Hangfire's connection-scoped lock, which lived exactly as long
+        /// as the enclosing using block, this one is a TTL: if a run outlasts it, another instance may start a parallel
+        /// run. Set generously - a full regeneration over a large asset store is measured in hours - and revisit if a
+        /// deployment ever legitimately exceeds it.
+        /// </summary>
+        private static readonly TimeSpan _generationLockTimeout = TimeSpan.FromHours(8);
+
         private readonly IPushNotificationManager _pushNotifier;
         private readonly IThumbnailGenerationProcessor _thumbnailProcessor;
         private readonly IThumbnailTaskService _taskService;
         private readonly IThumbnailTaskSearchService _taskSearchService;
+        private readonly IDistributedLockService _distributedLockService;
 
         public ThumbnailProcessJob(
             IPushNotificationManager pushNotifier,
             IThumbnailGenerationProcessor thumbnailProcessor,
             IThumbnailTaskService taskService,
-            IThumbnailTaskSearchService taskSearchService)
+            IThumbnailTaskSearchService taskSearchService,
+            IDistributedLockService distributedLockService)
         {
             _pushNotifier = pushNotifier;
             _thumbnailProcessor = thumbnailProcessor;
             _taskService = taskService;
             _taskSearchService = taskSearchService;
+            _distributedLockService = distributedLockService;
         }
 
         /// <summary>
         /// Run set of thumbnail tasks by TaskIds.
         /// </summary>
-        /// <param name="generateRequest"></param>
-        /// <param name="notifyEvent"></param>
-        /// <param name="cancellationToken">Hangfire sets the cancellation token</param>
-        /// <param name="context">Hangfire sets the process context</param>
-        [AutomaticRetry(Attempts = 0, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
-        public async Task Process(ThumbnailsTaskRunRequest generateRequest, ThumbnailProcessNotification notifyEvent, IJobCancellationToken cancellationToken, PerformContext context)
+        /// <param name="generateRequest">Which tasks to run, and whether to regenerate existing thumbnails.</param>
+        /// <param name="notifyEvent">Notification to report progress against; a fresh one is created when null.</param>
+        /// <param name="context">Job execution context supplied by the engine. Null when called outside a job.</param>
+        /// <param name="cancellationToken">Cancelled on shutdown and on job cancellation.</param>
+        /// <remarks>
+        /// The retry policy that used to sit here as [AutomaticRetry(Attempts = 0, OnAttemptsExceeded = Delete)] is now
+        /// set per enqueue, through EnqueueOptions.MaxRetryAttempts = 0 - see the callers.
+        /// </remarks>
+        public async Task Process(
+            ThumbnailsTaskRunRequest generateRequest,
+            ThumbnailProcessNotification notifyEvent,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken = default)
         {
+            notifyEvent ??= new ThumbnailProcessNotification(Guid.NewGuid().ToString());
+
             try
             {
-                if (notifyEvent == null)
-                {
-                    notifyEvent = new ThumbnailProcessNotification(Guid.NewGuid().ToString());
-                }
-
                 Action<ThumbnailTaskProgress> progressCallback = x =>
                 {
                     notifyEvent.Description = x.Message;
@@ -56,19 +77,20 @@ namespace VirtoCommerce.ImageToolsModule.Data.BackgroundJobs
                     notifyEvent.ErrorCount = notifyEvent.Errors.Count;
                     notifyEvent.TotalCount = x.TotalCount ?? 0;
                     notifyEvent.ProcessedCount = x.ProcessedCount ?? 0;
-                    notifyEvent.JobId = context.BackgroundJob.Id;
+                    // Engine-assigned id, so the admin UI can address this run - previously PerformContext.BackgroundJob.Id.
+                    notifyEvent.JobId = context?.JobId ?? notifyEvent.JobId;
 
                     _pushNotifier.Send(notifyEvent);
                 };
 
-                //wrap token 
                 var tasks = await _taskService.GetAsync(generateRequest.TaskIds);
 
                 await PerformGeneration(tasks, generateRequest.Regenerate, progressCallback, cancellationToken);
             }
-            catch (JobAbortedException)
+            catch (OperationCanceledException)
             {
-                //do nothing
+                // Stopped by shutdown or by an explicit cancellation - the JobAbortedException equivalent.
+                // Nothing to report: the run ended on purpose.
             }
             catch (Exception ex)
             {
@@ -91,11 +113,12 @@ namespace VirtoCommerce.ImageToolsModule.Data.BackgroundJobs
         /// <summary>
         /// Run all thumbnails tasks.
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        [AutomaticRetry(Attempts = 0, LogEvents = false, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
-        [DisableConcurrentExecution(10)]
-        public async Task ProcessAll(IJobCancellationToken cancellationToken)
+        /// <remarks>
+        /// The [DisableConcurrentExecution(10)] that used to guard this method is gone with the Hangfire reference, and
+        /// is not needed: <see cref="PerformGeneration"/> takes a distributed lock covering this path and the on-demand
+        /// one alike, and it does so across the whole worker fleet rather than one Hangfire server.
+        /// </remarks>
+        public async Task ProcessAll(CancellationToken cancellationToken = default)
         {
             var thumbnailTasks = await _taskSearchService.SearchAsync(new ThumbnailTaskSearchCriteria { Take = 0, Skip = 0 });
             var tasks = await _taskSearchService.SearchAsync(new ThumbnailTaskSearchCriteria { Take = thumbnailTasks.TotalCount, Skip = 0 });
@@ -105,34 +128,42 @@ namespace VirtoCommerce.ImageToolsModule.Data.BackgroundJobs
             await PerformGeneration(tasks.Results, false, progressCallback, cancellationToken);
         }
 
-        private async Task PerformGeneration(IEnumerable<ThumbnailTask> tasks, bool regenerate, Action<ThumbnailTaskProgress> progressCallback, IJobCancellationToken cancellationToken)
+        private async Task PerformGeneration(IEnumerable<ThumbnailTask> tasks, bool regenerate, Action<ThumbnailTaskProgress> progressCallback, CancellationToken cancellationToken)
         {
             try
             {
-                using (JobStorage.Current.GetConnection().AcquireDistributedLock("ThumbnailProcessJob", TimeSpan.Zero))
-                {
-                    var token = cancellationToken.ShutdownToken;
-
-                    foreach (var task in tasks)
+                // tryLockTimeout stays null on purpose: fail immediately when another run holds the lock, matching the
+                // TimeSpan.Zero that Hangfire's AcquireDistributedLock was called with. Waiting would queue duplicates.
+                await _distributedLockService.ExecuteAsync(
+                    GenerationLockKey,
+                    async () =>
                     {
-                        // Better to run and save tasks one by one to save LastRun date once every task is completed, opposing to waiting all tasks completion, as it could be a long process.
-                        var oneTaskArray = new[] { task };
-                        //Need to save runTime at start in order to not loose changes that may be done between the moment of getting changes and the task completion.
-                        var runTime = DateTime.UtcNow;
+                        foreach (var task in tasks)
+                        {
+                            // Better to run and save tasks one by one to save LastRun date once every task is completed, opposing to waiting all tasks completion, as it could be a long process.
+                            var oneTaskArray = new[] { task };
+                            //Need to save runTime at start in order to not loose changes that may be done between the moment of getting changes and the task completion.
+                            var runTime = DateTime.UtcNow;
 
-                        await _thumbnailProcessor.ProcessTasksAsync(oneTaskArray, regenerate, progressCallback, token);
+                            await _thumbnailProcessor.ProcessTasksAsync(oneTaskArray, regenerate, progressCallback, cancellationToken);
 
-                        task.LastRun = runTime;
+                            task.LastRun = runTime;
 
-                        await _taskService.SaveChangesAsync(oneTaskArray);
-                    }
+                            await _taskService.SaveChangesAsync(oneTaskArray);
+                        }
 
-                    var progressInfo = new ThumbnailTaskProgress { Message = "Thumbnails generated successfully!" };
-                    progressCallback(progressInfo);
-                }
+                        var progressInfo = new ThumbnailTaskProgress { Message = "Thumbnails generated successfully!" };
+                        progressCallback(progressInfo);
+
+                        return true;
+                    },
+                    lockTimeout: _generationLockTimeout,
+                    cancellationToken: cancellationToken);
             }
-            catch (DistributedLockTimeoutException)
+            catch (PlatformException)
             {
+                // Another run holds the lock. IDistributedLockService signals that as PlatformException, where Hangfire
+                // raised DistributedLockTimeoutException; the message shown to the user is unchanged.
                 var errorMsg = "A thumbnail generation process is currently running. Please wait until the process is complete before attempting to start another one.";
                 var progressInfo = new ThumbnailTaskProgress
                 {

--- a/src/VirtoCommerce.ImageToolsModule.Data/Handlers/BlobCreatedEventHandler.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Handlers/BlobCreatedEventHandler.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.AssetsModule.Core.Events;
 using VirtoCommerce.ImageToolsModule.Core;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.Services;
-using VirtoCommerce.ImageToolsModule.Data.BackgroundJobs;
+using VirtoCommerce.ImageToolsModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
 
 namespace VirtoCommerce.ImageToolsModule.Data.Handlers
@@ -65,12 +65,19 @@ namespace VirtoCommerce.ImageToolsModule.Data.Handlers
                 return;
             }
 
-            var runRequest = new ThumbnailsTaskRunRequest
+            var payload = AbstractTypeFactory<ThumbnailProcessJobPayload>.TryCreateInstance();
+            payload.RunRequest = new ThumbnailsTaskRunRequest
             {
                 TaskIds = tasksToRun.Select(x => x.Id).ToArray(),
             };
+            // No notification: this run was triggered by an uploaded blob, not by a user watching a progress bar.
+            // ThumbnailProcessJob.Process creates a throwaway one, exactly as it did when Hangfire passed null here.
+            payload.Notification = null;
 
-            BackgroundJob.Enqueue<ThumbnailProcessJob>(x => x.Process(runRequest, null, JobCancellationToken.Null, null));
+            // The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+            // the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+            // MaxRetryAttempts = 0 carries over [AutomaticRetry(Attempts = 0)] from the Hangfire job.
+            await BackgroundJob.Enqueue<ThumbnailProcessJobHandler>(payload, new EnqueueOptions { MaxRetryAttempts = 0 });
         }
 
         protected virtual List<string> GetOriginalItems(List<string> assetUrls, List<string> suffixCollection)

--- a/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessAllJobHandler.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessAllJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.ImageToolsModule.Data.BackgroundJobs;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.ImageToolsModule.Data.Jobs
+{
+    /// <summary>
+    /// Runs every configured thumbnail task. Target of the recurring schedule.
+    /// </summary>
+    public class ThumbnailProcessAllJobHandler(ThumbnailProcessJob job) : IBackgroundJobHandler<ThumbnailProcessAllJobPayload>
+    {
+        public virtual Task Execute(ThumbnailProcessAllJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.ProcessAll(cancellationToken);
+        }
+    }
+}

--- a/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessAllJobPayload.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessAllJobPayload.cs
@@ -1,0 +1,11 @@
+namespace VirtoCommerce.ImageToolsModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the recurring job that runs every configured thumbnail task. Carries no data: the schedule fires
+    /// with no arguments and the job discovers the tasks itself. It exists because the job API is payload-addressed,
+    /// and it stays a class so a partner module can extend it via AbstractTypeFactory.
+    /// </summary>
+    public class ThumbnailProcessAllJobPayload
+    {
+    }
+}

--- a/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessJobHandler.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.ImageToolsModule.Data.BackgroundJobs;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.ImageToolsModule.Data.Jobs
+{
+    /// <summary>
+    /// Runs a named set of thumbnail tasks, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="ThumbnailProcessJob"/>, which still owns the logic and stays callable by background
+    /// jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class ThumbnailProcessJobHandler(ThumbnailProcessJob job) : IBackgroundJobHandler<ThumbnailProcessJobPayload>
+    {
+        public virtual Task Execute(ThumbnailProcessJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.Process(payload.RunRequest, payload.Notification, context, cancellationToken);
+        }
+    }
+}

--- a/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessJobPayload.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Data/Jobs/ThumbnailProcessJobPayload.cs
@@ -1,0 +1,20 @@
+using VirtoCommerce.ImageToolsModule.Core.Models;
+using VirtoCommerce.ImageToolsModule.Core.PushNotifications;
+
+namespace VirtoCommerce.ImageToolsModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that runs a named set of thumbnail tasks.
+    /// </summary>
+    public class ThumbnailProcessJobPayload
+    {
+        public ThumbnailsTaskRunRequest RunRequest { get; set; }
+
+        /// <summary>
+        /// The notification created by the request that started the job, or null when the job was started by an event
+        /// rather than by a user. Carried in the payload, as the Hangfire job this replaces did, because the job
+        /// reports its progress against that same notification id.
+        /// </summary>
+        public ThumbnailProcessNotification Notification { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
+++ b/src/VirtoCommerce.ImageToolsModule.Data/VirtoCommerce.ImageToolsModule.Data.csproj
@@ -11,8 +11,7 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ImageToolsModule.Core\VirtoCommerce.ImageToolsModule.Core.csproj" />

--- a/src/VirtoCommerce.ImageToolsModule.Web/Controllers/Api/ThumbnailsTasksController.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/Controllers/Api/ThumbnailsTasksController.cs
@@ -1,12 +1,14 @@
+using System.Threading;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using VirtoCommerce.ImageToolsModule.Core.Models;
 using VirtoCommerce.ImageToolsModule.Core.PushNotifications;
 using VirtoCommerce.ImageToolsModule.Core.Services;
-using VirtoCommerce.ImageToolsModule.Data.BackgroundJobs;
+using VirtoCommerce.ImageToolsModule.Data.Jobs;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
 
@@ -107,23 +109,37 @@ namespace VirtoCommerce.ImageToolsModule.Web.Controllers.Api
         [HttpPost]
         [Route("{jobId}/cancel")]
         [Authorize(Permission.Read)]
-        public ActionResult Cancel([FromRoute] string jobId)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status501NotImplemented)]
+        public async Task<ActionResult> Cancel([FromRoute] string jobId, CancellationToken cancellationToken)
         {
-            BackgroundJob.Delete(jobId);
+            // Cancellation is engine-dependent: Hangfire can recall a job by id, RabbitMQ cannot - a published message
+            // is gone. Report that explicitly instead of answering 200 to a request that did nothing, so the admin UI
+            // can disable the button rather than pretend the run was stopped.
+            if (!BackgroundJob.SupportsCancellation)
+            {
+                return Problem(
+                    statusCode: StatusCodes.Status501NotImplemented,
+                    title: "Cancellation is not supported",
+                    detail: "The active background job engine cannot cancel a running job. Wait for the process to finish.");
+            }
+
+            await BackgroundJob.Delete(jobId, cancellationToken);
+
             return Ok();
         }
 
         [HttpPost]
         [Route("run")]
         [Authorize(Permission.Read)]
-        public ActionResult<ThumbnailProcessNotification> Run([FromBody] ThumbnailsTaskRunRequest runRequest)
+        public async Task<ActionResult<ThumbnailProcessNotification>> Run([FromBody] ThumbnailsTaskRunRequest runRequest)
         {
-            var notification = Enqueue(runRequest);
+            var notification = await Enqueue(runRequest);
             _pushNotifier.Send(notification);
             return Ok(notification);
         }
 
-        private ThumbnailProcessNotification Enqueue(ThumbnailsTaskRunRequest runRequest)
+        private async Task<ThumbnailProcessNotification> Enqueue(ThumbnailsTaskRunRequest runRequest)
         {
             var notification = new ThumbnailProcessNotification(_userNameResolver.GetCurrentUserName())
             {
@@ -132,7 +148,16 @@ namespace VirtoCommerce.ImageToolsModule.Web.Controllers.Api
             };
             _pushNotifier.Send(notification);
 
-            var jobId = BackgroundJob.Enqueue<ThumbnailProcessJob>(x => x.Process(runRequest, notification, JobCancellationToken.Null, null));
+            var payload = AbstractTypeFactory<ThumbnailProcessJobPayload>.TryCreateInstance();
+            payload.RunRequest = runRequest;
+            payload.Notification = notification;
+
+            // MaxRetryAttempts = 0 carries over [AutomaticRetry(Attempts = 0)] from the Hangfire job: a failed
+            // generation run is reported through the notification, not retried behind the user's back.
+            var jobId = await BackgroundJob.Enqueue<ThumbnailProcessJobHandler>(payload, new EnqueueOptions { MaxRetryAttempts = 0 });
+
+            // Set after the enqueue, as before: the payload copy the engine serialized carries no id, and the running
+            // job fills it in from IJobExecutionContext.JobId. This assignment is for the HTTP response only.
             notification.JobId = jobId;
 
             return notification;

--- a/src/VirtoCommerce.ImageToolsModule.Web/Module.cs
+++ b/src/VirtoCommerce.ImageToolsModule.Web/Module.cs
@@ -1,8 +1,7 @@
-using System;
+using System;
 using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -15,6 +14,7 @@ using VirtoCommerce.ImageToolsModule.Core.ThumbnailGeneration;
 using VirtoCommerce.ImageToolsModule.Data.BackgroundJobs;
 using VirtoCommerce.ImageToolsModule.Data.ExportImport;
 using VirtoCommerce.ImageToolsModule.Data.Handlers;
+using VirtoCommerce.ImageToolsModule.Data.Jobs;
 using VirtoCommerce.ImageToolsModule.Data.Models;
 using VirtoCommerce.ImageToolsModule.Data.MySql;
 using VirtoCommerce.ImageToolsModule.Data.PostgreSql;
@@ -25,6 +25,7 @@ using VirtoCommerce.ImageToolsModule.Data.ThumbnailGeneration;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -32,7 +33,6 @@ using VirtoCommerce.Platform.Data.Extensions;
 using VirtoCommerce.Platform.Data.MySql.Extensions;
 using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
 using VirtoCommerce.Platform.Data.SqlServer.Extensions;
-using VirtoCommerce.Platform.Hangfire;
 
 namespace VirtoCommerce.ImageToolsModule.Web
 {
@@ -95,6 +95,17 @@ namespace VirtoCommerce.ImageToolsModule.Web
 
             serviceCollection.AddTransient<ThumbnailsExportImport>();
             serviceCollection.AddTransient<BlobCreatedEventHandler>();
+
+            serviceCollection.AddTransient<ThumbnailProcessJob>();
+            serviceCollection.AddBackgroundJob<ThumbnailProcessJobHandler, ThumbnailProcessJobPayload>();
+
+            // Schedule periodic image processing. Registered here rather than in PostInitialize: the schedule is now a
+            // DI registration the engine module picks up, not an imperative call on a resolved service.
+            serviceCollection.AddRecurringJob<ThumbnailProcessAllJobHandler, ThumbnailProcessAllJobPayload>(schedule => schedule
+                .WithId(nameof(ThumbnailProcessAllJobHandler))
+                .FromSettings(
+                    ModuleConstants.Settings.General.EnableImageProcessJob,
+                    ModuleConstants.Settings.General.ImageProcessJobCronExpression));
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)
@@ -114,16 +125,6 @@ namespace VirtoCommerce.ImageToolsModule.Web
             //Register module permissions
             var permissionsRegistrar = appBuilder.ApplicationServices.GetRequiredService<IPermissionsRegistrar>();
             permissionsRegistrar.RegisterPermissions(ModuleInfo.Id, "Thumbnail", ModuleConstants.Security.Permissions.AllPermissions);
-
-            //Schedule periodic image processing job
-            var recurringJobService = appBuilder.ApplicationServices.GetService<IRecurringJobService>();
-
-            recurringJobService.WatchJobSetting(
-                new SettingCronJobBuilder()
-                    .SetEnablerSetting(ModuleConstants.Settings.General.EnableImageProcessJob)
-                    .SetCronSetting(ModuleConstants.Settings.General.ImageProcessJobCronExpression)
-                    .ToJob<ThumbnailProcessJob>(x => x.ProcessAll(JobCancellationToken.Null))
-                    .Build());
 
             //Force migrations
             using (var serviceScope = appBuilder.ApplicationServices.CreateScope())

--- a/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
+++ b/src/VirtoCommerce.ImageToolsModule.Web/module.manifest
@@ -3,9 +3,10 @@
   <id>VirtoCommerce.ImageTools</id>
   <version>3.1004.0</version>
   <version-tag />
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
   </dependencies>
   <title>Image Tools</title>
   <description>Image tools helps to automate thumbnail generation procedures with resizing and cropping</description>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5686

### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps job scheduling and locking infrastructure while preserving generation behavior; lock TTL and engine-dependent cancellation can change operational behavior in multi-node or long-running runs.
> 
> **Overview**
> Moves thumbnail generation off **Hangfire** onto the platform **BackgroundJobs** stack (platform **3.1052.0**, new **`VirtoCommerce.BackgroundJobs`** manifest dependency). **`VirtoCommerce.Platform.Hangfire`** is dropped from the Data project.
> 
> On-demand runs (API and blob-upload handler) enqueue **`ThumbnailProcessJobHandler`** with **`ThumbnailProcessJobPayload`** and **`EnqueueOptions.MaxRetryAttempts = 0`**. The cron-driven “process all tasks” path is registered via **`AddRecurringJob`** for **`ThumbnailProcessAllJobHandler`** instead of **`IRecurringJobService`** in **`PostInitialize`**.
> 
> **`ThumbnailProcessJob`** keeps the core logic but takes **`IJobExecutionContext`** / **`CancellationToken`**, uses **`IDistributedLockService`** with the same lock key **`ThumbnailProcessJob`** (8-hour TTL), and maps lock contention to the existing user-facing message via **`PlatformException`**.
> 
> The cancel endpoint returns **501** when **`BackgroundJob.SupportsCancellation`** is false so the admin UI does not assume a stop worked on engines that cannot recall jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da64923a6966b77ca3b3adc06c7b616c6e1744a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->